### PR TITLE
Add support for multi-key bindings

### DIFF
--- a/ModConfig.cs
+++ b/ModConfig.cs
@@ -1,16 +1,12 @@
-﻿using System;
-using Microsoft.Xna.Framework;
-using StardewModdingAPI;
-using StardewModdingAPI.Events;
+﻿using StardewModdingAPI;
 using StardewModdingAPI.Utilities;
-using StardewValley;
 
 namespace MultitoolMod
 {
     class ModConfig
     {
-        public SButton ToolButton { get; set; } = SButton.Q;
-        public SButton InfoButton { get; set; } = SButton.N;
-        public SButton CleanButton { get; set; } = SButton.C;
+        public KeybindList ToolButton { get; set; } = KeybindList.ForSingle(SButton.Q);
+        public KeybindList InfoButton { get; set; } = KeybindList.ForSingle(SButton.N);
+        public KeybindList CleanButton { get; set; } = KeybindList.ForSingle(SButton.C);
     }
 }

--- a/MultitoolMod.cs
+++ b/MultitoolMod.cs
@@ -1,18 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
-using xTile.Dimensions;
-using xTile.ObjectModel;
-using xTile.Tiles;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
-using StardewModdingAPI.Utilities;
-using StardewValley.TerrainFeatures;
-using StardewValley.Locations;
 using StardewValley;
 using MultitoolMod.Framework;
-using SObject = StardewValley.Object;
-using Rectangle = Microsoft.Xna.Framework.Rectangle;
 
 namespace MultitoolMod
 {
@@ -30,16 +22,17 @@ namespace MultitoolMod
         public override void Entry(IModHelper helper)
         {
             this.Config = this.Helper.ReadConfig<ModConfig>();
-            helper.Events.Input.ButtonPressed += this.onButtonPressed;
+            helper.Events.Input.ButtonsChanged += this.OnButtonsChanged;
             this.multitool = new Multitool(this);
         }
 
-        private void onButtonPressed(object sender, ButtonPressedEventArgs e)
+        private void OnButtonsChanged(object sender, ButtonsChangedEventArgs e)
         {
             // ignore if player hasn't loaded a save yet
             if (!Context.IsWorldReady)
                 return;
-            if (e.Button == this.Config.InfoButton)
+
+            if (this.Config.InfoButton.JustPressed())
             {
                 multitool.cursor = e.Cursor;
                 int x = (int)e.Cursor.AbsolutePixels.X;
@@ -55,7 +48,7 @@ namespace MultitoolMod
                 this.Monitor.Log(formattedProperties);
                 Game1.addHUDMessage(new HUDMessage(formattedProperties));
             }
-            else if (e.Button == this.Config.ToolButton)
+            else if (this.Config.ToolButton.JustPressed())
             {
                 multitool.cursor = e.Cursor;
                 int powerupLevel = 1;


### PR DESCRIPTION
This lets users configure [multi-key bindings](https://stardewvalleywiki.com/Modding:Player_Guide/Key_Bindings#Multi-key_bindings) like `LeftShoulder, LeftControl + N`. Previous `config.json` files will still work fine, since the `SButton` format is forward-compatible with `KeybindList`.